### PR TITLE
Responses and deletion parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Required fields, explanations where needed, and examples.
 
 Note that for CDM, the hookID:refID mapping file is a valid submission. That's the file produced by [ArchivesSpace_Script's](https://gitlab.lib.unc.edu/cappdev/ArchivesSpace_Scripts) `hookids/instance_to_hookid.rb`.
 
+## Responses
+
+If there were no errors, a 200 response is provided. There is no further information provided (e.g. what changes were made in ArchivesSpace or whether any changes were made in ArchivesSpace).
+
+In the case of client-side errors, a 400 is returned with lists of any errors. The user should address any client-side errors before resubmitting the data.
+
+In the case of only server-side errors, a 500 is returned with a list of any errors. Contact the local administrator of this plugin / ArchivesSpace to resolve any issues.
+
 ## Example shell usage
 
 The example data files in `examples/` have faked digital content data. However, the ref_ids specified in those files are ref_ids that are seeded in archette's TEST database/repository, so the examples below will create DOs on those seeded archival objects. If you have overwritten/deleted the TEST repository, the examples will not create DOs since the specified AOs are missing.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ In the ArchivesSpace `config.rb`:
 - delete: ['none' (default), 'global']
   - 'global' means that managed DOs not found in the digital content data being submitted will be deleted. This means you must supply a complete set of digital content data for the given source
   - 'none' means that managed DOs not found in the digital content data being submitted will be left in place. You may submit an incomplete set of digital content data to get some specified DOs created/managed, without the manager deleting all of the DOs left out of your submission
+- deletion_threshold: [`nil` (default), '1', '2', ...]
+  - Sets a minimum record threshold such that if the submitted data does not contain at least that many records, no deletions or DO unlinking will be performed. This prevents the plugin from committing mass deletions in the event faulty/incomplete data is submitted.
 
 NOTE: the repository number in the URL (e.g. ".../repositories/2/...") should be the repository you want to act on.
 

--- a/backend/controllers/digital_object_manager_controller.rb
+++ b/backend/controllers/digital_object_manager_controller.rb
@@ -7,7 +7,8 @@ class ArchivesSpaceService < Sinatra::Base
           .params(["repo_id", :repo_id],
                   ["digital_content", :body_stream, "The CSV listing digital content record metadata"],
                   ["source", String, "Content source, either 'dcr' or 'cdm'"],
-                  ["delete", String, "Scope of deletions for records missing from csv, either 'global' or 'none' (default)", :default => 'none'])
+                  ["delete", String, "Scope of deletions for records missing from csv, either 'global' or 'none' (default)", :default => 'none'],
+                  ["deletion_threshold", Integer, "Minimum submitted record count required to allow deletion", :default => nil])
           .permissions([:update_digital_object_record, :delete_archival_record])
           .use_transaction(false)
           .returns([200, :created],
@@ -27,7 +28,7 @@ class ArchivesSpaceService < Sinatra::Base
     #########
 
     ArchivesSpace::DigitalObjectManager.new(source: params[:source], repo_id: params[:repo_id]).
-      handle_datafile(tempfile, deletion_scope: params[:delete])
+      handle_datafile(tempfile, deletion_scope: params[:delete], deletion_threshold: params[:deletion_threshold])
 
     # TODO: better response
     [200, "Okay"]

--- a/backend/lib/digital_object_manager.rb
+++ b/backend/lib/digital_object_manager.rb
@@ -114,6 +114,7 @@ module ArchivesSpace
 
                 response[:server_errors] ||= []
                 response[:server_errors] << e.message
+                log.warn(e.message)
 
                 # Roll back to the savepoint
                 raise Sequel::Rollback, e
@@ -141,7 +142,7 @@ module ArchivesSpace
 
       rescue UnmetDeletionThresholdError => e
         response[:client_errors] ||= []
-        response[:client_errors] << e.message)
+        response[:client_errors] << e.message
         log.warn(e.message)
       end
 


### PR DESCRIPTION
- Adds a `deletion_threshold` parameter which stops the plugin from deleting or unlinking DOs if it receives fewer records than specified in the parameter
- API provides valid response codes and, when applicable, a list of errors
- minor log messaging fix