### PR TITLE
AS-760: Construct CDM URLs that lead to sorted results

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Required fields, explanations where needed, and examples.
     - '01234-z'
   - **aspace_hookid**
     - '01234_folder_3'
+  - **cdm_alias** the cdm-collectionNumber/cdmAlias for the given EAD collection/collid (some EAD collections are in their own CDM collection; some EAD collections are in a bucket CDM collection that includes multiple EAD collections)
+    - '01234'
+    - '00ddd'
 - DCR:
   - **ref_id** - ref_id for the corresponding AO
     - 'fcee5fc2bb61effc8836498a8117b05d'

--- a/backend/lib/digital_content_data.rb
+++ b/backend/lib/digital_content_data.rb
@@ -10,7 +10,7 @@ module ArchivesSpace
   class DigitalContentData
     attr_reader :source, :content_id, :ref_id,
                 :content_title,
-                :collection_number, :aspace_hookid,
+                :collection_number, :aspace_hookid, :cdm_alias,
                 :validated
 
     def initialize(args = {})
@@ -22,6 +22,7 @@ module ArchivesSpace
 
       @collection_number = args[:collection_number]
       @aspace_hookid = args[:aspace_hookid]
+      @cdm_alias = args[:cdm_alias]
     end
 
     # Returns DO Model corresponding to the metadata source

--- a/backend/lib/digital_object_manager.rb
+++ b/backend/lib/digital_object_manager.rb
@@ -54,7 +54,8 @@ module ArchivesSpace
                   content_title: row['content_title'] || row['work_title'],
                   # cdm
                   collection_number: row['collid'],
-                  aspace_hookid: row['aspace_hookid']
+                  aspace_hookid: row['aspace_hookid'],
+                  cdm_alias: row['cdm_alias']
                 )
 
                 digital_object_id = input_data.digital_object_id

--- a/spec/cdm_digital_object_spec.rb
+++ b/spec/cdm_digital_object_spec.rb
@@ -8,7 +8,8 @@ module ArchivesSpace
         content_id: '01234_box_5',
         ref_id: 'fcee5fc2bb61effc8836498a8117b05d',
         collection_number: '01234-z',
-        aspace_hookid: '01234_documentcase_5678'
+        aspace_hookid: '01234_documentcase_5678',
+        cdm_alias: '01ddd'
       )
     end
     let(:cdm_dig_obj) { CdmDigitalObject.new(content_data, ao_title: 'My AO Title') }
@@ -26,7 +27,7 @@ module ArchivesSpace
         expect(subject['title']).to eq('Document Case 5: My AO Title')
         expect(subject['publish']).to be true
         expect(subject['file_versions'].length).to eq(1)
-        expect(subject['file_versions'].first['file_uri']).to eq('https://dc.lib.unc.edu/cdm/search/searchterm/box_5!01234-z/field/all!all/mode/exact!exact/conn/and!and')
+        expect(subject['file_versions'].first['file_uri']).to eq('https://dc.lib.unc.edu/cdm/search/collection/01ddd/searchterm/box_5!01234-z/field/all!all/mode/exact!exact/conn/and!and/order/relatid')
         expect(subject['file_versions'].first['publish']).to be true
         expect(subject['file_versions'].first['use_statement']).to eq('link')
         expect(subject['file_versions'].first['xlink_actuate_attribute']).to eq('onRequest')


### PR DESCRIPTION
- CdmDigitalObjects use a `cdm_alias` value provided to them at initialization to construct a better CDM search URL that returns results sorted by filename