### PR TITLE
Allow updating digital objects

### DIFF
--- a/backend/controllers/digital_object_manager_controller.rb
+++ b/backend/controllers/digital_object_manager_controller.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class ArchivesSpaceService < Sinatra::Base
-  # See README for csv specifications
+  # Deprecated by ".../digital_object_manager/manage"
   Endpoint.post('/repositories/:repo_id/digital_object_manager')
           .description("Creates and deletes managed DOs")
           .params(["repo_id", :repo_id],
                   ["digital_content", :body_stream, "The CSV listing digital content record metadata"],
                   ["source", String, "Content source, either 'dcr' or 'cdm'"],
-                  ["delete", String, "Scope of deletions for records missing from csv, either 'global' or 'none' (default)", :default => 'none'],
+                  ["delete", String, "Scope of deletions for records missing from csv, either 'none', 'global', or 'submission'", :default => 'none'],
                   ["deletion_threshold", Integer, "Minimum submitted record count required to allow deletion", :default => nil])
           .permissions([:update_digital_object_record, :delete_archival_record])
           .use_transaction(false)
@@ -15,6 +15,48 @@ class ArchivesSpaceService < Sinatra::Base
                   [400, :error],
                   [500, :error]) \
   do
+    manage_or_update(params, update_digital_object_metadata: false)
+  end
+
+  Endpoint.post('/repositories/:repo_id/digital_object_manager/manage')
+          .description("Creates and deletes managed DOs")
+          .params(["repo_id", :repo_id],
+                  ["digital_content", :body_stream, "The CSV listing digital content record metadata"],
+                  ["source", String, "Content source, either 'dcr' or 'cdm'"],
+                  ["delete", String, "Scope of deletions for records missing from csv, either 'none', 'global', or 'submission'", :default => 'none'],
+                  ["deletion_threshold", Integer, "Minimum submitted record count required to allow deletion", :default => nil])
+          .permissions([:update_digital_object_record, :delete_archival_record])
+          .use_transaction(false)
+          .returns([200, :created],
+                  [400, :error],
+                  [500, :error]) \
+  do
+    manage_or_update(params, update_digital_object_metadata: false)
+  end
+
+  # See README for csv and parameter specifications
+  # Inteded use of this endpoint is to update metadata and/or the AO links for existing
+  # maanged DOs. It can still create or delete DOs in the same way as the `/manage`` endpoint,
+  # but somewhat less efficiently. So generally do not use this endpoint when `/manage`
+  # will suffice.
+  Endpoint.post('/repositories/:repo_id/digital_object_manager/update')
+          .description("Updates metadata/links for existing managed DOs.")
+          .params(["repo_id", :repo_id],
+                  ["digital_content", :body_stream, "The CSV listing digital content record metadata"],
+                  ["source", String, "Content source, either 'dcr' or 'cdm'"],
+                  ["delete", String, "Scope of deletions for records missing from csv, either 'none', 'global', or 'submission'", :default => 'none'])
+          .permissions([:update_digital_object_record, :delete_archival_record])
+          .use_transaction(false)
+          .returns([200, :created],
+                  [400, :error],
+                  [500, :error]) \
+  do
+    manage_or_update(params, update_digital_object_metadata: true)
+  end
+
+  private
+
+  def manage_or_update(params, update_digital_object_metadata: false)
     ## stream handling from ArchivesSpace: backend\app\controllers\batch_import.rb
     stream = params[:digital_content]
     tempfile = ASUtils.tempfile('import_stream')
@@ -29,7 +71,9 @@ class ArchivesSpaceService < Sinatra::Base
     #########
 
     manager = ArchivesSpace::DigitalObjectManager.new(source: params[:source], repo_id: params[:repo_id])
-    response = manager.handle_datafile(tempfile, deletion_scope: params[:delete], deletion_threshold: params[:deletion_threshold])
+    response = manager.handle_datafile(tempfile, deletion_scope: params[:delete],
+                                       deletion_threshold: params[:deletion_threshold],
+                                       update_digital_object_metadata: update_digital_object_metadata)
 
     if response[:client_errors]
       json_response(response, 400)

--- a/backend/lib/cdm_digital_object.rb
+++ b/backend/lib/cdm_digital_object.rb
@@ -27,7 +27,7 @@ module ArchivesSpace
       @aspace_hookid = content_data.aspace_hookid
       @cdm_alias = content_data.cdm_alias
 
-      @ao_title = kwargs[:ao_title]
+      @ao_title = content_data.ao_title
     end
 
     def aspace_container_type
@@ -79,7 +79,8 @@ module ArchivesSpace
     end
 
     def digital_object_title
-      "#{container_label} #{container_indicator}: #{ao_title}"
+      unescaped_ao_title = self.class.partially_unescape_title(ao_title)
+      "#{container_label} #{container_indicator}: #{unescaped_ao_title}"
     end
 
     def container_label

--- a/backend/lib/digital_content_data.rb
+++ b/backend/lib/digital_content_data.rb
@@ -10,7 +10,7 @@ module ArchivesSpace
   class DigitalContentData
     attr_reader :source, :content_id, :ref_id,
                 :content_title,
-                :collection_number, :aspace_hookid, :cdm_alias,
+                :collection_number, :aspace_hookid, :cdm_alias, :ao_title,
                 :validated
 
     def initialize(args = {})
@@ -23,6 +23,7 @@ module ArchivesSpace
       @collection_number = args[:collection_number]
       @aspace_hookid = args[:aspace_hookid]
       @cdm_alias = args[:cdm_alias]
+      @ao_title = args[:ao_title]
     end
 
     # Returns DO Model corresponding to the metadata source

--- a/backend/lib/digital_object_manager.rb
+++ b/backend/lib/digital_object_manager.rb
@@ -55,7 +55,8 @@ module ArchivesSpace
                   # cdm
                   collection_number: row['collid'],
                   aspace_hookid: row['aspace_hookid'],
-                  cdm_alias: row['cdm_alias']
+                  cdm_alias: row['cdm_alias'],
+                  ao_title: row['ao_title']
                 )
 
                 digital_object_id = input_data.digital_object_id
@@ -76,17 +77,14 @@ module ArchivesSpace
                 # for which a DO already exists
                 input_data.validate
                 log.debug("Validated: #{digital_object_id}, #{ref_id}")
+                digital_object = get_or_create_digital_object(input_data)
 
                 archival_object = ArchivalObject.find(ref_id: ref_id)
                 unless archival_object
                   raise RefIDNotFoundError, "AO not found for ref_id: #{ref_id}"
                 end
                 archival_object_json = ArchivalObject.to_jsonmodel(archival_object)
-
-                digital_object = get_or_create_digital_object(
-                  input_data,
-                  ao_title: archival_object_json['title']
-                )
+                
                 add_digital_object_instance!(archival_object_json: archival_object_json,
                                             digital_object: digital_object)
 

--- a/backend/lib/managed_digital_object.rb
+++ b/backend/lib/managed_digital_object.rb
@@ -12,29 +12,86 @@ module ArchivesSpace
       raise NoMethodError, "Use `ManagedDigitalObject.from_data` or instantiate a subclass directly"
     end
 
-    def jsonmodel
-      model = bare_dig_obj_jsonmodel
+    def ==(other)
+      other_jsonmodel =
+        if other.is_a?(DigitalObject)
+          DigitalObject.to_jsonmodel(other)
+        elsif other.is_a?(JSONModel(:digital_object))
+          other
+        end
+      if other_jsonmodel
+        payload_jsonmodel_data.each do |k, v|
+          if k == "file_versions"
+            return false unless v.length == other_jsonmodel[k].length
 
-      model["publish"] = true
-      model["title"] = digital_object_title
-      model["digital_object_id"] = digital_object_id
-      model["file_versions"] = [
-        {
-          "jsonmodel_type" => "file_version",
-          "file_uri" => uri,
-          "use_statement" => role,
-          "xlink_actuate_attribute" => "onRequest",
-          "xlink_show_attribute" => "new",
-          "publish" => true
-      }
-      ]
-      model
+            v.each.with_index do |file_version, i|
+              file_version.each do |k2, v2|
+                return false unless v2 == other_jsonmodel[k][i][k2]
+              end
+             end
+          else
+            return false unless other_jsonmodel[k] == v
+          end
+        end
+        return true
+      end
+
+      super
+    end
+
+    def jsonmodel
+      merge_jsonmodel_payload(bare_dig_obj_jsonmodel)
+    end
+
+    # Merge incoming payload data into base/existing jsonmodel data
+    # For the file_versions array, merge each incoming file_version onto an existing
+    # (or new, if needed) file_version, then remove any excess existing file_versions
+    def merge_jsonmodel_payload(base_jsonmodel)
+      json = base_jsonmodel.dup
+
+      payload_jsonmodel_data.each do |k, v|
+        if k == "file_versions"
+          v.each.with_index do |file_version, i|
+            json[k][i] ||= {}
+            json[k][i].merge!(file_version)
+          end
+          json[k].slice!(v.length..-1) if json[k].length > v.length
+        else 
+          json[k] = v
+        end
+      end
+
+      json
     end
 
     private
 
     def bare_dig_obj_jsonmodel
       JSONModel(:digital_object).new
+    end
+
+    # A hash that approximates a slice of Digital Object jsonmodel,
+    # retaining only the elements we care about setting.
+    #
+    # Elements not included here we leave to Aspace to set/manage.
+    # Only elements here are used in determining whether a ManagedDigitalObject
+    # is equivalent to an ArchivesSpace::DigitalObject
+    def payload_jsonmodel_data
+      {
+        "publish" => true,
+        "title" => digital_object_title,
+        "digital_object_id" => digital_object_id,
+        "file_versions" => [
+          {
+            "jsonmodel_type" => "file_version",
+            "file_uri" => uri,
+            "use_statement" => role,
+            "xlink_actuate_attribute" => "onRequest",
+            "xlink_show_attribute" => "new",
+            "publish" => true
+          }
+        ]
+      }
     end
 
     def digital_object_id
@@ -65,8 +122,6 @@ module ArchivesSpace
     def self.partially_unescape_title(title)
       return title unless title
 
-      #title.gsub(/\\t/, "\t").gsub(/\\\\(?!t)/, "\\")
-      #title.gsub(/\\([t\\])/) { |m| '\\' + $1}
       title.gsub(/\\([t\\])/) { $1 == 't' ? "\t" : "\\" }
     end
   end

--- a/backend/lib/managed_digital_object.rb
+++ b/backend/lib/managed_digital_object.rb
@@ -58,5 +58,16 @@ module ArchivesSpace
       raise NoMethodError, "#{self.class} must implement .validate"
     end
     class ValidationError < RuntimeError; end
+
+    # Unescapes "\t" and "\\" into literal tab and backslash characters, which is required for the Aspace
+    # title to include those literal characters. Other escape sequences, e.g. "\n" are not unescaped,
+    # because it is not obvious including those literals in Aspace titles is desirable.
+    def self.partially_unescape_title(title)
+      return title unless title
+
+      #title.gsub(/\\t/, "\t").gsub(/\\\\(?!t)/, "\\")
+      #title.gsub(/\\([t\\])/) { |m| '\\' + $1}
+      title.gsub(/\\([t\\])/) { $1 == 't' ? "\t" : "\\" }
+    end
   end
 end

--- a/spec/cdm_digital_object_spec.rb
+++ b/spec/cdm_digital_object_spec.rb
@@ -40,13 +40,13 @@ module ArchivesSpace
 
       describe 'character escaping in titles' do
         it 'unescapes tabs and backslashes in title' do
-          # we're passing the literal escape sequences `\t` and `\\``
+          # we're passing the literal *escape sequences* `\t` and `\\``
           content_data[:ao_title] = "My AO Title with \\t tab and \\\\ backslash"
           expect(subject['title']).to eq("Document Case 5: My AO Title with \t tab and \\ backslash")
         end
 
         it 'literal tabs and backslashes remain literal in title' do
-          # we're passing a literal tab and literal backslash`
+          # we're passing a literal tab and literal backslash *characters*`
           content_data[:ao_title] = "My AO Title with \t tab and \\ backslash"
           expect(subject['title']).to eq("Document Case 5: My AO Title with \t tab and \\ backslash")
         end

--- a/spec/cdm_digital_object_spec.rb
+++ b/spec/cdm_digital_object_spec.rb
@@ -2,24 +2,28 @@ require_relative 'spec_helper'
 
 module ArchivesSpace
   RSpec.describe 'CdmDigitalObject', type: :digital_object_manager do
+
+    def jsonmodel_from_content_data(content_data)
+      digital_content_data = DigitalContentData.new(content_data)
+      cdm_dig_obj = CdmDigitalObject.new(digital_content_data)
+      allow(cdm_dig_obj).to receive(:bare_dig_obj_jsonmodel).and_return(bare_dig_obj_jsonmodel)
+      cdm_dig_obj.jsonmodel
+    end
+
     let(:content_data) do
-      DigitalContentData.new(
+      {
         source: 'cdm',
         content_id: '01234_box_5',
         ref_id: 'fcee5fc2bb61effc8836498a8117b05d',
         collection_number: '01234-z',
         aspace_hookid: '01234_documentcase_5678',
-        cdm_alias: '01ddd'
-      )
+        cdm_alias: '01ddd',
+        ao_title: 'My AO Title'
+      }
     end
-    let(:cdm_dig_obj) { CdmDigitalObject.new(content_data, ao_title: 'My AO Title') }
 
     describe '#jsonmodel' do
-      let(:subject) { cdm_dig_obj.jsonmodel }
-
-      before(:each) do
-        allow(cdm_dig_obj).to receive(:bare_dig_obj_jsonmodel).and_return(bare_dig_obj_jsonmodel)
-      end
+      let(:subject) { jsonmodel_from_content_data(content_data) }
 
       it 'returns correct CDM jsonmodel', :aggregate_failures do
         expect(subject['jsonmodel_type']).to eq('digital_object')
@@ -32,6 +36,26 @@ module ArchivesSpace
         expect(subject['file_versions'].first['use_statement']).to eq('link')
         expect(subject['file_versions'].first['xlink_actuate_attribute']).to eq('onRequest')
         expect(subject['file_versions'].first['xlink_show_attribute']).to eq('new')
+      end
+
+      describe 'character escaping in titles' do
+        it 'unescapes tabs and backslashes in title' do
+          # we're passing the literal escape sequences `\t` and `\\``
+          content_data[:ao_title] = "My AO Title with \\t tab and \\\\ backslash"
+          expect(subject['title']).to eq("Document Case 5: My AO Title with \t tab and \\ backslash")
+        end
+
+        it 'literal tabs and backslashes remain literal in title' do
+          # we're passing a literal tab and literal backslash`
+          content_data[:ao_title] = "My AO Title with \t tab and \\ backslash"
+          expect(subject['title']).to eq("Document Case 5: My AO Title with \t tab and \\ backslash")
+        end
+
+        it 'Aspace titles can still contain literal escape sequences' do
+          # passing `\\t` and `\\\\` to get `\t` and `\\` in the titles`
+          content_data[:ao_title] = 'My AO Title with \\\\t tab and \\\\\\\\ backslash'
+          expect(subject['title']).to eq('Document Case 5: My AO Title with \\t tab and \\\\ backslash')
+        end
       end
     end
   end

--- a/spec/managed_digital_object_spec.rb
+++ b/spec/managed_digital_object_spec.rb
@@ -1,0 +1,39 @@
+require_relative 'spec_helper'
+
+module ArchivesSpace
+  RSpec.describe 'ManagedDigitalObject', type: :digital_object_manager do
+    describe '#partially_unescape_title' do
+      def unescape(title)
+        ManagedDigitalObject.partially_unescape_title(title)
+      end
+      
+      it 'unescapes `\t`' do
+        expect(unescape("\\t")).to eq("\t")
+      end
+
+      it 'unescapes `\\`' do
+        expect(unescape("\\\\")).to eq("\\")
+      end
+
+      it 'does not unescape every special character' do
+        expect(unescape("\\n")).to eq("\\n")
+      end
+
+      it "literal '\t' can be represented by '\\t'" do
+        expect(unescape('\\\\t')).to eq('\\t')
+      end
+
+      it "literal '\\' can be represented by '\\\\'" do
+        expect(unescape("\\\\\\\\")).to eq("\\\\")
+      end
+
+      it "backslash followed by tab can be represented by '\\\t'" do
+        expect(unescape('\\\\\\t')).to eq("\\\t")
+      end
+
+      it 'literal tabs are unaffected' do
+        expect(unescape('	')).to eq("\t")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add a `digital_object_manager/update` endpoint that updates metadata of existing DOs as needed based on submitted data
- Deprectate `manage` endpoint in favor of  `digital_object_manager/manage`
- Add `submission` as an option for the `delete` parameter.With `delete=submission`, only DOs represented in the submission will potentially have instances deleted. This allows for instances to be deleted/"moved" outside of a full content ingest/submission.
- CDM Digital Objects titles, which are based on the AO title, use submitted AO title data rather than reading the AO title live. This makes it cheaper to see if a DO's metadata has changed