### PR TITLE
DCR validation

### DIFF
--- a/backend/lib/dcr_digital_object.rb
+++ b/backend/lib/dcr_digital_object.rb
@@ -18,15 +18,15 @@ module ArchivesSpace
     end
 
     def self.validate(input_data)
-      unless input_data.ref_id.match?(/^\h{32}$/)
+      unless input_data.ref_id&.match?(/^\h{32}$/)
         raise ValidationError, "Invalid ref_id: #{input_data.ref_id}"
       end
 
-      unless input_data.content_id.match?(/^\h{8}\-\h{4}\-\h{4}\-\h{4}\-\h{12}$/)
+      unless input_data.content_id&.match?(/^\h{8}\-\h{4}\-\h{4}\-\h{4}\-\h{12}$/)
         raise ValidationError, "Invalid content_id: #{input_data.content_id}"
       end
 
-      unless input_data.content_title.match?(/^[[:print:]]+$/)
+      unless input_data.content_title&.match?(/^[[:print:]]+$/)
         raise ValidationError, "Invalid content_title: #{input_data.content_title}"
       end
     end

--- a/backend/lib/dcr_digital_object.rb
+++ b/backend/lib/dcr_digital_object.rb
@@ -26,7 +26,7 @@ module ArchivesSpace
         raise ValidationError, "Invalid content_id: #{input_data.content_id}"
       end
 
-      unless input_data.content_title&.match?(/^[[:print:]]+$/)
+      unless input_data.content_title&.match?(/^[[:print:]\t]+$/)
         raise ValidationError, "Invalid content_title: #{input_data.content_title}"
       end
     end

--- a/spec/dcr_digital_object_spec.rb
+++ b/spec/dcr_digital_object_spec.rb
@@ -30,5 +30,58 @@ module ArchivesSpace
         expect(subject['file_versions'].first['xlink_show_attribute']).to eq('new')
       end
     end
+
+    describe '.validate' do
+
+      let(:input_data) do
+        {
+          source: 'dcr',
+          ref_id: 'fcee5fc2bb61effc8836498a8117b05d',
+          content_id: '12345678-abcd-abcd-abcd-1234567890ab',
+          content_title: 'My Work Title'
+        }
+      end
+
+      let(:subject) { DcrDigitalObject.validate(DigitalContentData.new(input_data)) }
+
+      it 'succeeds for valid input data' do
+        expect { subject }.not_to raise_error
+      end
+
+      it 'fails for wrongly structured ref_ids' do
+        input_data[:ref_id] = 'abcd'
+        expect { subject }.to raise_error(ArchivesSpace::ManagedDigitalObject::ValidationError)
+      end
+
+      it 'fails for nil ref_ids' do
+        input_data.delete(:ref_id)
+        expect { subject }.to raise_error(ArchivesSpace::ManagedDigitalObject::ValidationError)
+      end
+
+      it 'fails for wrongly structured content_ids (UUIDs)' do
+        input_data[:content_id] = 'abcd'
+        expect { subject }.to raise_error(ArchivesSpace::ManagedDigitalObject::ValidationError)
+      end
+
+      it 'fails for nil content_id (UUIDS)' do
+        input_data.delete(:content_id)
+        expect { subject }.to raise_error(ArchivesSpace::ManagedDigitalObject::ValidationError)
+      end
+
+      it 'fails for content_titles that include control characters' do
+        input_data[:content_title] = "Some Title with \x00 control character"
+        expect { subject }.to raise_error(ArchivesSpace::ManagedDigitalObject::ValidationError)
+      end
+
+      it 'fails for content_titles that are empty' do
+        input_data[:content_title] = ''
+        expect { subject }.to raise_error(ArchivesSpace::ManagedDigitalObject::ValidationError)
+      end
+
+      it 'fails for nil content_titles' do
+        input_data.delete(:content_title)
+        expect { subject }.to raise_error(ArchivesSpace::ManagedDigitalObject::ValidationError)
+      end
+    end
   end
 end

--- a/spec/dcr_digital_object_spec.rb
+++ b/spec/dcr_digital_object_spec.rb
@@ -68,6 +68,11 @@ module ArchivesSpace
         expect { subject }.to raise_error(ArchivesSpace::ManagedDigitalObject::ValidationError)
       end
 
+      it 'succeeds for content_titles that include tabs' do
+        input_data[:content_title] = "Some Title with a literal tab: \t"
+        expect { subject }.not_to raise_error
+      end
+
       it 'fails for content_titles that include control characters' do
         input_data[:content_title] = "Some Title with \x00 control character"
         expect { subject }.to raise_error(ArchivesSpace::ManagedDigitalObject::ValidationError)


### PR DESCRIPTION
- DCR validation fails gracefully when required elements are nil
- DCR validation allows literal tabs in `content_title`
- Add DCR validation tests